### PR TITLE
Allow tbvaccine to be used as a python module

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,8 +27,11 @@ You are done!
 Usage as a command-line utility
 ===============================
 
-TBVaccine can be used from the command line. Just pipe STDERR into it from the
-program you want to watch::
+TBVaccine can be used from the command line several ways.::
+
+    python -m tbvaccine myscript.py
+
+Or just pipe STDERR into it from the program you want to watch::
 
     ./myscript.py 2>&1 | tbvaccine
 

--- a/tbvaccine/__main__.py
+++ b/tbvaccine/__main__.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import tbvaccine
+
+tbvaccine.add_hook()
+
+# Check that a script was passed in.
+if len(sys.argv) <= 1:
+    raise SystemExit("Usage: python -m tbvaccine my_script.py")
+
+# Check that the script exists.
+script_path = sys.argv[1]
+if not os.path.exists(script_path):
+    raise SystemExit("Error: '%s' does not exist" % script_path)
+
+# Replace tbvaccine's dir with script's dir in the module search path.
+sys.path[0] = os.path.dirname(script_path)
+
+# Remove tbvaccine from the arg list.
+del sys.argv[0]
+
+with open(script_path) as script_file:
+    code = compile(script_file.read(), script_path, 'exec')
+    variables = {}
+    exec(code, variables, variables)
+


### PR DESCRIPTION
This code is inspired by the one in [colored-traceback](https://github.com/staticshock/colored-traceback.py/blob/master/colored_traceback/__main__.py). It allows tbvaccine to be launched with `python -m tbvaccine somescript.py`, so anyone can test it without editing any code or piping the stderr output.