### PR TITLE
adding __main__ as a variable

### DIFF
--- a/tbvaccine/__main__.py
+++ b/tbvaccine/__main__.py
@@ -21,6 +21,8 @@ del sys.argv[0]
 
 with open(script_path) as script_file:
     code = compile(script_file.read(), script_path, 'exec')
-    variables = {}
+    variables = {
+        '__name__': '__main__'
+    }
     exec(code, variables, variables)
 


### PR DESCRIPTION
- fix `if` for main programs

```
print('__name__ is %r' % __name__)

if __name__ == '__main__':
    raise Exception('hello')
```