### PR TITLE
Cap long lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 build/
 dist/
 *.egg-info/
-__pycahce__/
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build/
 dist/
 *.egg-info/
+__pycahce__/


### PR DESCRIPTION
I'm having issues where I have *very* long variables (like a spreadsheet loaded in memory) and so when TBVaccine prints that, I lose everything else in my console buffer. Here is a quick and dirty hack to cap line length. It works by dropping ANSI sequences from long variable lines, and cap  their length at 79*4 chars (approx. 4 output lines). A note is added to the line that there is more un-printed data.

(I can't figure out how to get decent lengths with normal string slicing on strings with ANSI codes embedded. For example, the output line `|     __annotations__ = {}` clocks in with a length of 148 (!) due to ANSI control codes.)

The downside of dropping ANSI sequences like this is that the line won't be coloured....