### PR TITLE
FIX: code_dir inclusion on Windows

### DIFF
--- a/tbvaccine/tbv.py
+++ b/tbvaccine/tbv.py
@@ -73,7 +73,8 @@ class TBVaccine:
         """
         Decide whether the file in the traceback is one in our code_dir or not.
         """
-        return self._file.startswith(self._code_dir) or not self._file.startswith("/")
+        return (self._file.startswith(self._code_dir) or
+                (sys.platform != 'win32' and not self._file.startswith("/")))
 
     def _process_var_line(self, line):
         """


### PR DESCRIPTION
I am using `tbvaccine` on Windows and the library was highlighting/colouring every line on the traceback because of the second conditional based on the filename starting with `/`, which on Windows will be always `True`.

I made this small change to make it work on Windows.
