### PR TITLE
Add TBVACCINE_FORCE for non-isatty stderr

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,12 @@ Or fish::
 
     set -x TBVACCINE=1
 
+If you want to prettify tracebacks even when stderr is not a tty, set
+`TBVACCINE_FORCE` to 1::
+
+    export TBVACCINE=1
+    export TBVACCINE_FORCE=1
+    python -c '1/0' 2>&1 | cat  # pretty!
 
 NOTE: If you're on Ubuntu, you most likely have Apport installed, which overrides
 TBVaccine's hook with its own. To disable Apport for Python, delete a file named

--- a/tbvaccine/tbv.py
+++ b/tbvaccine/tbv.py
@@ -249,7 +249,7 @@ class TBVaccine:
 
 
 def add_hook(*args, **kwargs):
-    if not getattr(sys.stderr, "isatty", lambda: False)():
+    if os.getenv("TBVACCINE_FORCE") != "1" and not sys.stderr.isatty():
         return
     tbv = TBVaccine(*args, **kwargs)
     sys.excepthook = tbv.print_exception


### PR DESCRIPTION
Closes #28

Ref.

- better-exceptions: [FORCE_COLOR](https://github.com/Qix-/better-exceptions/blob/0.2.2/better_exceptions/color.py#L90)
- logzero: [LOGZERO_FORCE_COLOR](https://github.com/metachris/logzero/blob/v1.5.0/logzero/__init__.py#L249)
