### PR TITLE
Fix startup error when config dir not exist

### DIFF
--- a/tbvaccine/tbv.py
+++ b/tbvaccine/tbv.py
@@ -60,10 +60,7 @@ class TBVaccine:
     def _load_config(self):
         dir_path = user_config_dir("tbvaccine")
         config_path = os.path.join(dir_path, "tbvaccine.cfg")
-        try:
-            os.mkdir(dir_path)
-        except OSError:
-            pass
+        os.makedirs(dir_path, exist_ok=True)
 
         if not os.path.exists(config_path):
             with open(config_path, "w") as configfile:


### PR DESCRIPTION
Fix error If `~/.config/` doesn't exist (usual in docker containers):

```hs
root@4fd8085c7d11:/# python3 /mnt/tes.py
Error processing line 1 of /usr/local/lib/python3.7/site-packages/tbvaccine.pth:

  Traceback (most recent call last):
    File "/usr/local/lib/python3.7/site.py", line 168, in addpackage
      exec(line)
    File "<string>", line 1, in <module>
    File "<string>", line 3, in <module>
    File "/usr/local/lib/python3.7/site-packages/tbvaccine/tbv.py", line 258, in add_hook
      tbv = TBVaccine(*args, **kwargs)
    File "/usr/local/lib/python3.7/site-packages/tbvaccine/tbv.py", line 55, in __init__
      self._load_config()
    File "/usr/local/lib/python3.7/site-packages/tbvaccine/tbv.py", line 69, in _load_config
      with open(config_path, "w") as configfile:
  FileNotFoundError: [Errno 2] No such file or directory: '/root/.config/tbvaccine/tbvaccine.cfg'

Remainder of file ignored
```
