### PR TITLE
Fix CodeShelter link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ TBVaccine
 ---------
 
 .. image:: https://www.codeshelter.co/static/badges/badge-flat.svg
-    :target: www.codeshelter.co
+    :target: https://www.codeshelter.co
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/ambv/black
 


### PR DESCRIPTION
Otherwise it was a relative link, and so was returning a GitHub 404 error page. --> https://github.com/skorokithakis/tbvaccine/blob/master/www.codeshelter.co