### PR TITLE
Simplify isatty

### DIFF
--- a/tbvaccine/tbv.py
+++ b/tbvaccine/tbv.py
@@ -249,7 +249,7 @@ class TBVaccine:
 
 
 def add_hook(*args, **kwargs):
-    if not getattr(sys.stderr, "isatty", lambda: False)():
+    if not sys.stderr.isatty():
         return
     tbv = TBVaccine(*args, **kwargs)
     sys.excepthook = tbv.print_exception


### PR DESCRIPTION
`IOBase.stderr()` has existed from at latest Python 2.7.4 and 3.1 (https://github.com/python/cpython/commit/4fa88fa0b), so `sys.stderr.isatty()` likely exists.